### PR TITLE
Replace API gateway and auth-service containers

### DIFF
--- a/api-gateway/docker-compose.yml
+++ b/api-gateway/docker-compose.yml
@@ -1,40 +1,17 @@
-#C:\Repos\Laravel-Microservices\api-gateway\docker-compose.yml
 services:
   api-gateway:
-    build:
-      context: ./api-gateway
-      dockerfile: Dockerfile
-    env_file: api-gateway/.env
+    image: kong:3.6
     container_name: api-gateway
-    restart: unless-stopped
+    environment:
+      KONG_DATABASE: "off"
+      KONG_DECLARATIVE_CONFIG: /usr/local/kong/declarative/kong.yml
     volumes:
-      - ./api-gateway:/var/www/html
+      - ./kong.yml:/usr/local/kong/declarative/kong.yml
     ports:
-      - "8000:80"
-      - "8443:443"
+      - "8000:8000"
+      - "8443:8443"
+      - "8001:8001"
+      - "8444:8444"
     networks:
       - internal
-      # - net-api-gateway-analytics-service
-      # - net-api-gateway-auth-service
-      # - net-api-gateway-catalog-service
-      # #- net-api-gateway-frontend
-      # - net-api-gateway-notification-service
-      # - net-api-gateway-order-service
-      # - net-api-gateway-payment-service
-      # - net-api-gateway-user-service
-      # - net-redis-api-gateway
-    depends_on:
-      - redis
-    
-# networks:
-#   net-api-gateway-analytics-service:        { external: true }
-#   net-api-gateway-auth-service:             { external: true }
-#   net-api-gateway-catalog-service:          { external: true }
-#   #net-api-gateway-frontend:                 { external: true }
-#   net-api-gateway-notification-service:     { external: true }
-#   net-api-gateway-order-service:            { external: true }
-#   net-api-gateway-payment-service:          { external: true }
-#   net-api-gateway-user-service:             { external: true }
-#   net-redis-api-gateway:                    { external: true }
-    
-
+    restart: unless-stopped

--- a/api-gateway/kong.yml
+++ b/api-gateway/kong.yml
@@ -1,0 +1,2 @@
+_format_version: "3.0"
+services: []

--- a/auth-service/docker-compose.yml
+++ b/auth-service/docker-compose.yml
@@ -1,28 +1,13 @@
-#C:\Repos\Laravel-Microservices\auth-service\docker-compose.yml
 services:
-  auth-service:                                    # servizio Laravel “auth-service”
-    build:                                              # builda un’immagine partendo dal Dockerfile in questa cartella
-      context: ./auth-service
-      dockerfile: Dockerfile
-    container_name: auth-service                   # nome fisso del container
-    env_file: auth-service/.env                      # carica variabili (DB, app key, ecc.) dal file .env locale
+  auth-service:
+    image: quay.io/keycloak/keycloak:24.0.1
+    container_name: auth-service
+    command: start-dev
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
     ports:
-      - "8001:80"
-    volumes:
-      - ./auth-service:/var/www/html                             # bind-mount del sorgente: ogni modifica locale si vede subito nel container
-    depends_on:                                         # ordine di avvio (non health-check)
-      - sql-server                                    
-      - redis
-      - rabbitmq
+      - "8001:8080"
     networks:
       - internal
-      # - net-api-gateway-auth-service
-      # - net-rabbitmq-auth-service
-      # - net-redis-auth-service
-      # - net-sql-server-auth-service                # rete verso il gruppo SQL Server 1
-
-# networks:
-#   net-api-gateway-auth-service: { external: true }
-#   net-rabbitmq-auth-service:    { external: true }
-#   net-redis-auth-service:       { external: true }
-#   net-sql-server-auth-service:  { external: true }
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- switch `api-gateway` service to a Kong container
- swap the Laravel `auth-service` for a Keycloak container
- include a basic declarative config file for Kong

## Testing
- `git status --short`
- `git log -1 --stat`
