### PR TITLE
Fix gateway proxy config keys

### DIFF
--- a/api-gateway/config/gateway.php
+++ b/api-gateway/config/gateway.php
@@ -2,12 +2,14 @@
 
 return [
     'services' => [
-        'auth'         => env('AUTH_SERVICE_URL',         'http://auth-service:8001'),
-        'catalog'      => env('CATALOG_SERVICE_URL',      'http://catalog-service:8002'),
-        'order'        => env('ORDER_SERVICE_URL',        'http://order-service:8003'),
-        'payment'      => env('PAYMENT_SERVICE_URL',      'http://payment-service:8004'),
-        'user'         => env('USER_SERVICE_URL',         'http://user-service:8005'),
-        'analytics'    => env('ANALYTICS_SERVICE_URL',    'http://analytics-service:8006'),
-        'notification' => env('NOTIFICATION_SERVICE_URL', 'http://notification-service:8007'),
+        // Le chiavi devono corrispondere ai nomi dei container per il proxy
+        // del Gateway, altrimenti la configurazione non viene trovata.
+        'auth-service'         => env('AUTH_SERVICE_URL',         'http://auth-service:8001'),
+        'catalog-service'      => env('CATALOG_SERVICE_URL',      'http://catalog-service:8002'),
+        'order-service'        => env('ORDER_SERVICE_URL',        'http://order-service:8003'),
+        'payment-service'      => env('PAYMENT_SERVICE_URL',      'http://payment-service:8004'),
+        'user-service'         => env('USER_SERVICE_URL',         'http://user-service:8005'),
+        'analytics-service'    => env('ANALYTICS_SERVICE_URL',    'http://analytics-service:8006'),
+        'notification-service' => env('NOTIFICATION_SERVICE_URL', 'http://notification-service:8007'),
     ],
 ];


### PR DESCRIPTION
## Summary
- fix mismatch between route service names and gateway config

## Testing
- `php -l api-gateway/config/gateway.php` *(fails: `php` not found)*