### PR TITLE
Add infra init script and update docs

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,3 +1,31 @@
-# Service Contracts
+# Shared Service Contracts
 
-This directory contains language agnostic DTO definitions expressed as JSON schemas. Services in any language should adhere to these contracts when exchanging data.
+This folder stores all cross-service data contracts used in the microservice architecture.
+The contracts are defined using JSON Schema so that services written in any
+language can share the same message format.
+
+## Structure
+
+Each top level directory groups the schemas for a domain. Inside a domain folder
+there are `request` and `response` subfolders containing the payload definitions
+used when communicating with that service.
+
+For example the `user` folder contains:
+
+```
+contracts/
+└── user/
+    ├── request/   # payloads accepted from other services
+    └── response/  # payloads emitted by the user service
+```
+
+## Usage
+
+Services should validate incoming data against these schemas and generate
+outgoing messages that conform to them. Storing the contracts in a dedicated
+folder makes it easy to keep them version controlled and shareable across
+projects.
+
+The `contracts` directory is **not** a service on its own. It simply lives at the
+root so that every microservice can mount or copy the schemas during its build
+phase.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
     image: rabbitmq:3-management-alpine
     container_name: rabbitmq
     restart: unless-stopped
+    depends_on:
+      - redis
     environment:
       RABBITMQ_DEFAULT_USER: guest
       RABBITMQ_DEFAULT_PASS: guest
@@ -44,6 +46,8 @@ services:
     image: bitnami/zookeeper:latest
     container_name: zookeeper
     restart: unless-stopped
+    depends_on:
+      - rabbitmq
     environment:
       ALLOW_ANONYMOUS_LOGIN: "yes"
     volumes:
@@ -70,11 +74,17 @@ services:
     image: mcr.microsoft.com/mssql/server:2019-latest     # immagine MySQL 8.x ufficiale
     container_name: sql-server                            # nome fisso del container DB
     restart: unless-stopped                               # riavvia dopo crash, ma non se fermato a mano
+    depends_on:
+      - kafka
     environment:                                          # credenziali/database da creare al primo avvio
       ACCEPT_EULA: "Y"
       MSSQL_SA_PASSWORD: rootpass
     volumes:
       - sql-server-data:/var/opt/mssql
+      - ./setup.sql:/scripts/setup.sql:ro
+      - ./addpermissions.sql:/scripts/addpermissions.sql:ro
+      - ./init-sql-server.sh:/init-sql-server.sh:ro
+    command: ["/bin/bash", "/init-sql-server.sh"]
     networks:
       - internal
       # - net-sql-server-analytics-service

--- a/init-sql-server.sh
+++ b/init-sql-server.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Start SQL Server in the background
+/opt/mssql/bin/sqlservr &
+
+# Wait for SQL Server to start
+sleep 30
+
+# Execute initialization scripts
+/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -i /scripts/setup.sql
+/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -i /scripts/addpermissions.sql
+
+# Wait on SQL Server process
+wait

--- a/up-all.sh
+++ b/up-all.sh
@@ -1,1 +1,17 @@
-docker compose -f docker-compose.yml -f docker-compose.mgmt.yml -f api-gateway/docker-compose.yml -f analytics-service/docker-compose.yml -f auth-service/docker-compose.yml -f jwt-service/docker-compose.yml -f catalog-service/docker-compose.yml -f notification-service/docker-compose.yml -f order-service/docker-compose.yml -f payment-service/docker-compose.yml -f user-service/docker-compose.yml up -d
+#!/bin/bash
+set -e
+
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.mgmt.yml \
+  -f api-gateway/docker-compose.yml \
+  -f analytics-service/docker-compose.yml \
+  -f auth-service/docker-compose.yml \
+  -f jwt-service/docker-compose.yml \
+  -f catalog-service/docker-compose.yml \
+  -f notification-service/docker-compose.yml \
+  -f order-service/docker-compose.yml \
+  -f payment-service/docker-compose.yml \
+  -f user-service/docker-compose.yml \
+  -f frontend/docker-compose.yml \
+  up -d


### PR DESCRIPTION
## Summary
- expand `up-all.sh` to include frontend service
- ensure infrastructure containers start in order using `depends_on`
- run setup and permissions SQL during SQL Server startup
- explain shared contracts in new README

## Testing
- `bash -n up-all.sh`
