### PR TITLE
Resolve port conflicts in compose files

### DIFF
--- a/jwt-service/docker-compose.yml
+++ b/jwt-service/docker-compose.yml
@@ -7,7 +7,8 @@ services:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
     ports:
-      - "8080:8080"
+      # Use a dedicated host port to prevent conflicts with auth-service
+      - "8081:8080"
     networks:
       - internal
     restart: unless-stopped

--- a/laravel-gateway/docker-compose.yml
+++ b/laravel-gateway/docker-compose.yml
@@ -10,8 +10,10 @@ services:
     volumes:
       - ./laravel-gateway:/var/www/html
     ports:
-      - "8000:80"
-      - "8443:443"
+      # Expose on host port 8002 to avoid clashes with Kong
+      - "8002:80"
+      # Custom HTTPS port to prevent conflicts
+      - "8445:443"
     networks:
       - internal
       # - net-laravel-gateway-analytics-service


### PR DESCRIPTION
## Summary
- fix duplicate port for jwt-service
- avoid clash between Kong and Laravel gateway

## Testing
- `docker --version` *(fails: command not found)*