### PR TITLE
Fix compose paths

### DIFF
--- a/analytics-service/docker-compose.yml
+++ b/analytics-service/docker-compose.yml
@@ -2,14 +2,14 @@
 services:
   analytics-service:                                    # servizio Laravel “analytics-service”
     build:                                              # builda un’immagine partendo dal Dockerfile in questa cartella
-      context: ./analytics-service
+      context: .
       dockerfile: Dockerfile
     container_name: analytics-service                   # nome fisso del container
-    env_file: analytics-service/.env                    # carica variabili (DB, app key, ecc.) dal file .env locale
+    env_file: .env                                      # carica variabili (DB, app key, ecc.) dal file .env locale
     ports:
       - "8008:80"
     volumes:
-      - ./analytics-service:/var/www/html               # bind-mount del sorgente: ogni modifica locale si vede subito nel container
+      - ./:/var/www/html                                # bind-mount del sorgente: ogni modifica locale si vede subito nel container
     depends_on:                                         # ordine di avvio (non health-check)
       - sql-server                                    
       - redis

--- a/catalog-service/docker-compose.yml
+++ b/catalog-service/docker-compose.yml
@@ -2,14 +2,14 @@
 services:
   catalog-service:                                    # servizio Laravel “catalog-service”
     build:                                              # builda un’immagine partendo dal Dockerfile in questa cartella
-      context: ./catalog-service
+      context: .
       dockerfile: Dockerfile
     container_name: catalog-service                     # nome fisso del container
-    env_file: catalog-service/.env                    # carica variabili (DB, app key, ecc.) dal file .env locale
+    env_file: .env                                    # carica variabili (DB, app key, ecc.) dal file .env locale
     ports:
       - "8004:80"
     volumes:
-      - ./catalog-service:/var/www/html                       # bind-mount del sorgente: ogni modifica locale si vede subito nel container
+      - ./:/var/www/html                                   # bind-mount del sorgente: ogni modifica locale si vede subito nel container
     depends_on:                                         # ordine di avvio (non health-check)
       - sql-server                                    
       - redis

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -2,14 +2,14 @@
 services:
   frontend:                                             # servizio Laravel “frontend”
     build:                                              # builda un’immagine partendo dal Dockerfile in questa cartella
-      context: ./frontend
+      context: .
       dockerfile: Dockerfile
     container_name: frontend                            # nome fisso del container
-    env_file: frontend/.env                           # carica variabili (DB, app key, ecc.) dal file .env locale
+    env_file: .env                                    # carica variabili (DB, app key, ecc.) dal file .env locale
     ports:
       - "9000:80"
     volumes:
-      - ./frontend:/var/www/html                                # bind-mount del sorgente: ogni modifica locale si vede subito nel container
+      - ./:/var/www/html                                       # bind-mount del sorgente: ogni modifica locale si vede subito nel container
     depends_on:                                         # ordine di avvio (non health-check)
       - sql-server                                    
       - redis

--- a/keycloak-auth-service/docker-compose.yml
+++ b/keycloak-auth-service/docker-compose.yml
@@ -1,6 +1,5 @@
 services:
   keycloak-auth-service:
-    context: ./keycloak-auth-service
     image: quay.io/keycloak/keycloak:24.0.1
     container_name: keycloak-auth-service
     command: start-dev

--- a/kong-gateway/docker-compose.yml
+++ b/kong-gateway/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       KONG_DATABASE: "off"
       KONG_DECLARATIVE_CONFIG: /usr/local/kong/declarative/kong.yml
     volumes:
-      - ../kong-gateway/kong.yml:/usr/local/kong/declarative/kong.yml
+      - ./kong.yml:/usr/local/kong/declarative/kong.yml
     ports:
       - "8000:8000"
       - "8443:8443"

--- a/kong-gateway/kong.yml
+++ b/kong-gateway/kong.yml
@@ -1,0 +1,2 @@
+_format_version: "3.0"
+services: []

--- a/laravel-auth-service/docker-compose.yml
+++ b/laravel-auth-service/docker-compose.yml
@@ -2,14 +2,14 @@
 services:
   laravel-auth-service:                                    # servizio Laravel “laravel-auth-service”
     build:                                              # builda un’immagine partendo dal Dockerfile in questa cartella
-      context: ./laravel-auth-service
+      context: .
       dockerfile: Dockerfile
     container_name: laravel-auth-service                   # nome fisso del container
-    env_file: laravel-auth-service/.env                      # carica variabili (DB, app key, ecc.) dal file .env locale
+    env_file: .env                                           # carica variabili (DB, app key, ecc.) dal file .env locale
     ports:
       - "8001:80"
     volumes:
-      - ./laravel-auth-service:/var/www/html                             # bind-mount del sorgente: ogni modifica locale si vede subito nel container
+      - ./:/var/www/html                                                # bind-mount del sorgente: ogni modifica locale si vede subito nel container
     depends_on:                                         # ordine di avvio (non health-check)
       - sql-server                                    
       - redis

--- a/laravel-gateway/docker-compose.yml
+++ b/laravel-gateway/docker-compose.yml
@@ -2,13 +2,13 @@
 services:
   laravel-gateway:
     build:
-      context: ./laravel-gateway
+      context: .
       dockerfile: Dockerfile
-    env_file: laravel-gateway/.env
+    env_file: .env
     container_name: laravel-gateway
     restart: unless-stopped
     volumes:
-      - ./laravel-gateway:/var/www/html
+      - ./:/var/www/html
     ports:
       # Expose on host port 8002 to avoid clashes with Kong
       - "8002:80"

--- a/notification-service/docker-compose.yml
+++ b/notification-service/docker-compose.yml
@@ -2,14 +2,14 @@
 services:
   notification-service:                                 # servizio Laravel “notification-service”
     build:                                              # builda un’immagine partendo dal Dockerfile in questa cartella
-      context: ./notification-service
+      context: .
       dockerfile: Dockerfile
     container_name: notification-service                # nome fisso del container
-    env_file: notification-service/.env               # carica variabili (DB, app key, ecc.) dal file .env locale
+    env_file: .env                                    # carica variabili (DB, app key, ecc.) dal file .env locale
     ports:
       - "8007:80"
     volumes:
-      - ./notification-service:/var/www/html                               # bind-mount del sorgente: ogni modifica locale si vede subito nel container
+      - ./:/var/www/html                                                 # bind-mount del sorgente: ogni modifica locale si vede subito nel container
     depends_on:                                         # ordine di avvio (non health-check)
       - sql-server                                    
       - redis

--- a/order-service/docker-compose.yml
+++ b/order-service/docker-compose.yml
@@ -2,14 +2,14 @@
 services:
   order-service:                                    # servizio Laravel “order-service”
     build:                                              # builda un’immagine partendo dal Dockerfile in questa cartella
-      context: ./order-service
+      context: .
       dockerfile: Dockerfile
     container_name: order-service                   # nome fisso del container
-    env_file: order-service/.env                      # carica variabili (DB, app key, ecc.) dal file .env locale
+    env_file: .env                                    # carica variabili (DB, app key, ecc.) dal file .env locale
     ports:
       - "8005:80"
     volumes:
-      - ./order-service:/var/www/html                   # bind-mount del sorgente: ogni modifica locale si vede subito nel container
+      - ./:/var/www/html                                # bind-mount del sorgente: ogni modifica locale si vede subito nel container
     depends_on:                                         # ordine di avvio (non health-check)
       - sql-server                                    
       - redis

--- a/payment-service/docker-compose.yml
+++ b/payment-service/docker-compose.yml
@@ -2,14 +2,14 @@
 services:
   payment-service:                                      # servizio Laravel “payment-service”
     build:                                              # builda un’immagine partendo dal Dockerfile in questa cartella
-      context: ./payment-service
+      context: .
       dockerfile: Dockerfile
     container_name: payment-service                     # nome fisso del container
-    env_file: payment-service/.env                    # carica variabili (DB, app key, ecc.) dal file .env locale
+    env_file: .env                                    # carica variabili (DB, app key, ecc.) dal file .env locale
     ports:
       - "8006:80"
     volumes:
-      - ./payment-service:/var/www/html                              # bind-mount del sorgente: ogni modifica locale si vede subito nel container
+      - ./:/var/www/html                                            # bind-mount del sorgente: ogni modifica locale si vede subito nel container
     depends_on:                                         # ordine di avvio (non health-check)
       - sql-server                                    
       - redis

--- a/user-service/docker-compose.yml
+++ b/user-service/docker-compose.yml
@@ -2,14 +2,14 @@
 services:
   user-service:                                         # servizio Laravel “user-service”
     build:                                              # builda un’immagine partendo dal Dockerfile in questa cartella
-      context: ./user-service
+      context: .
       dockerfile: Dockerfile
     container_name: user-service                        # nome fisso del container
-    env_file: user-service/.env                       # carica variabili (DB, app key, ecc.) dal file .env locale
+    env_file: .env                                    # carica variabili (DB, app key, ecc.) dal file .env locale
     ports:
       - "8003:80"
     volumes:
-      - ./user-service:/var/www/html                               # bind-mount del sorgente: ogni modifica locale si vede subito nel container
+      - ./:/var/www/html                                          # bind-mount del sorgente: ogni modifica locale si vede subito nel container
     depends_on:                                         # ordine di avvio (non health-check)
       - sql-server
       - redis


### PR DESCRIPTION
## Summary
- fix docker-compose contexts for each service
- provide kong.yml for kong-gateway
- do not reference laravel-gateway path in kong-gateway

## Testing
- `docker compose -f kong-gateway/docker-compose.yml config` *(fails: `docker: command not found`)*