### PR TITLE
Fix artisan not found error

### DIFF
--- a/analytics-service/Dockerfile
+++ b/analytics-service/Dockerfile
@@ -102,6 +102,7 @@ COPY vhost.conf /etc/apache2/sites-available/000-default.conf
 #COPY /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/catalog-service/Dockerfile
+++ b/catalog-service/Dockerfile
@@ -102,6 +102,7 @@ COPY vhost.conf /etc/apache2/sites-available/000-default.conf
 #COPY /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -102,6 +102,7 @@ COPY vhost.conf /etc/apache2/sites-available/000-default.conf
 #COPY /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/laravel-auth-service/Dockerfile
+++ b/laravel-auth-service/Dockerfile
@@ -102,6 +102,7 @@ COPY vhost.conf /etc/apache2/sites-available/000-default.conf
 #COPY /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/laravel-gateway/Dockerfile
+++ b/laravel-gateway/Dockerfile
@@ -102,6 +102,7 @@ COPY vhost.conf /etc/apache2/sites-available/000-default.conf
 #COPY /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -102,6 +102,7 @@ COPY vhost.conf /etc/apache2/sites-available/000-default.conf
 #COPY /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/order-service/Dockerfile
+++ b/order-service/Dockerfile
@@ -102,6 +102,7 @@ COPY vhost.conf /etc/apache2/sites-available/000-default.conf
 #COPY /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/payment-service/Dockerfile
+++ b/payment-service/Dockerfile
@@ -102,6 +102,7 @@ COPY vhost.conf /etc/apache2/sites-available/000-default.conf
 #COPY /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -102,6 +102,7 @@ COPY vhost.conf /etc/apache2/sites-available/000-default.conf
 #COPY /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 RUN chown -R www-data:www-data /var/www/html
+WORKDIR /var/www/html
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
## Summary
- ensure every Laravel service container runs with the project directory as the working directory

## Testing
- `git status --short`