### PR TITLE
Add basic CRUD controllers and routes

### DIFF
--- a/analytics-service/app/Http/Controllers/EventController.php
+++ b/analytics-service/app/Http/Controllers/EventController.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Event;
+use Illuminate\Http\Request;
+
+class EventController extends Controller
+{
+    public function index()
+    {
+        return response()->json(Event::all());
+    }
+
+    public function store(Request $request)
+    {
+        $event = Event::create($request->only(['event_name','user_id','properties']));
+        return response()->json($event, 201);
+    }
+
+    public function show(Event $event)
+    {
+        return response()->json($event);
+    }
+
+    public function update(Request $request, Event $event)
+    {
+        $event->update($request->only(['event_name','user_id','properties']));
+        return response()->json($event);
+    }
+
+    public function destroy(Event $event)
+    {
+        $event->delete();
+        return response()->noContent();
+    }
+}

--- a/analytics-service/app/Models/Event.php
+++ b/analytics-service/app/Models/Event.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Event extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'event_name',
+        'user_id',
+        'properties',
+    ];
+
+    protected $casts = [
+        'properties' => 'array',
+    ];
+}

--- a/analytics-service/database/migrations/0001_01_01_000003_create_events_table.php
+++ b/analytics-service/database/migrations/0001_01_01_000003_create_events_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('events', function (Blueprint $table) {
+            $table->id();
+            $table->string('event_name');
+            $table->string('user_id')->nullable();
+            $table->json('properties')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('events');
+    }
+};

--- a/analytics-service/routes/api.php
+++ b/analytics-service/routes/api.php
@@ -1,0 +1,5 @@
+<?php
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\EventController;
+
+Route::apiResource('events', EventController::class);

--- a/catalog-service/app/Http/Controllers/ProductController.php
+++ b/catalog-service/app/Http/Controllers/ProductController.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use Illuminate\Http\Request;
+
+class ProductController extends Controller
+{
+    public function index()
+    {
+        return response()->json(Product::all());
+    }
+
+    public function store(Request $request)
+    {
+        $product = Product::create($request->only(['name','description','price']));
+        return response()->json($product, 201);
+    }
+
+    public function show(Product $product)
+    {
+        return response()->json($product);
+    }
+
+    public function update(Request $request, Product $product)
+    {
+        $product->update($request->only(['name','description','price']));
+        return response()->json($product);
+    }
+
+    public function destroy(Product $product)
+    {
+        $product->delete();
+        return response()->noContent();
+    }
+}

--- a/catalog-service/app/Models/Product.php
+++ b/catalog-service/app/Models/Product.php
@@ -1,0 +1,16 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'price',
+    ];
+}

--- a/catalog-service/database/migrations/0001_01_01_000003_create_products_table.php
+++ b/catalog-service/database/migrations/0001_01_01_000003_create_products_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->decimal('price', 10, 2);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/catalog-service/routes/api.php
+++ b/catalog-service/routes/api.php
@@ -1,0 +1,5 @@
+<?php
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ProductController;
+
+Route::apiResource('products', ProductController::class);

--- a/notification-service/app/Http/Controllers/NotificationController.php
+++ b/notification-service/app/Http/Controllers/NotificationController.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Notification;
+use Illuminate\Http\Request;
+
+class NotificationController extends Controller
+{
+    public function index()
+    {
+        return response()->json(Notification::all());
+    }
+
+    public function store(Request $request)
+    {
+        $notification = Notification::create($request->only(['user_id','message','channel','status']));
+        return response()->json($notification, 201);
+    }
+
+    public function show(Notification $notification)
+    {
+        return response()->json($notification);
+    }
+
+    public function update(Request $request, Notification $notification)
+    {
+        $notification->update($request->only(['user_id','message','channel','status']));
+        return response()->json($notification);
+    }
+
+    public function destroy(Notification $notification)
+    {
+        $notification->delete();
+        return response()->noContent();
+    }
+}

--- a/notification-service/app/Models/Notification.php
+++ b/notification-service/app/Models/Notification.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Notification extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'message',
+        'channel',
+        'status',
+    ];
+}

--- a/notification-service/database/migrations/0001_01_01_000003_create_notifications_table.php
+++ b/notification-service/database/migrations/0001_01_01_000003_create_notifications_table.php
@@ -1,0 +1,23 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->id();
+            $table->string('user_id');
+            $table->string('message');
+            $table->string('channel');
+            $table->string('status')->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/notification-service/routes/api.php
+++ b/notification-service/routes/api.php
@@ -1,0 +1,5 @@
+<?php
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\NotificationController;
+
+Route::apiResource('notifications', NotificationController::class);

--- a/order-service/app/Http/Controllers/OrderController.php
+++ b/order-service/app/Http/Controllers/OrderController.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Order;
+use Illuminate\Http\Request;
+
+class OrderController extends Controller
+{
+    public function index()
+    {
+        return response()->json(Order::all());
+    }
+
+    public function store(Request $request)
+    {
+        $order = Order::create($request->only(['user_id','items','total','status']));
+        return response()->json($order, 201);
+    }
+
+    public function show(Order $order)
+    {
+        return response()->json($order);
+    }
+
+    public function update(Request $request, Order $order)
+    {
+        $order->update($request->only(['user_id','items','total','status']));
+        return response()->json($order);
+    }
+
+    public function destroy(Order $order)
+    {
+        $order->delete();
+        return response()->noContent();
+    }
+}

--- a/order-service/app/Models/Order.php
+++ b/order-service/app/Models/Order.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'items',
+        'total',
+        'status',
+    ];
+
+    protected $casts = [
+        'items' => 'array',
+    ];
+}

--- a/order-service/database/migrations/0001_01_01_000003_create_orders_table.php
+++ b/order-service/database/migrations/0001_01_01_000003_create_orders_table.php
@@ -1,0 +1,23 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('orders', function (Blueprint $table) {
+            $table->id();
+            $table->string('user_id');
+            $table->json('items');
+            $table->decimal('total', 10, 2);
+            $table->string('status')->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('orders');
+    }
+};

--- a/order-service/routes/api.php
+++ b/order-service/routes/api.php
@@ -1,0 +1,5 @@
+<?php
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\OrderController;
+
+Route::apiResource('orders', OrderController::class);

--- a/payment-service/app/Http/Controllers/PaymentController.php
+++ b/payment-service/app/Http/Controllers/PaymentController.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Models\Payment;
+use Illuminate\Http\Request;
+
+class PaymentController extends Controller
+{
+    public function index()
+    {
+        return response()->json(Payment::all());
+    }
+
+    public function store(Request $request)
+    {
+        $payment = Payment::create($request->only(['order_id','amount','method','status']));
+        return response()->json($payment, 201);
+    }
+
+    public function show(Payment $payment)
+    {
+        return response()->json($payment);
+    }
+
+    public function update(Request $request, Payment $payment)
+    {
+        $payment->update($request->only(['order_id','amount','method','status']));
+        return response()->json($payment);
+    }
+
+    public function destroy(Payment $payment)
+    {
+        $payment->delete();
+        return response()->noContent();
+    }
+}

--- a/payment-service/app/Models/Payment.php
+++ b/payment-service/app/Models/Payment.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Payment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_id',
+        'amount',
+        'method',
+        'status',
+    ];
+}

--- a/payment-service/database/migrations/0001_01_01_000003_create_payments_table.php
+++ b/payment-service/database/migrations/0001_01_01_000003_create_payments_table.php
@@ -1,0 +1,23 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('payments', function (Blueprint $table) {
+            $table->id();
+            $table->string('order_id');
+            $table->decimal('amount', 10, 2);
+            $table->string('method');
+            $table->string('status')->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payments');
+    }
+};

--- a/payment-service/routes/api.php
+++ b/payment-service/routes/api.php
@@ -1,0 +1,5 @@
+<?php
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\PaymentController;
+
+Route::apiResource('payments', PaymentController::class);

--- a/user-service/app/Http/Controllers/UserController.php
+++ b/user-service/app/Http/Controllers/UserController.php
@@ -5,10 +5,11 @@
     use App\DTO\Requests\UserRequest\RequestLoginUserDto;
     use App\Services\UserServices\UserService;
     use Illuminate\Http\Request;
+    use App\Models\User;
 
-    class UserController extends Controller
-    {
-        private UserService $userService;
+class UserController extends Controller
+{
+    private UserService $userService;
 
         public function __construct(UserService $userService)
         {
@@ -26,7 +27,7 @@
             return response()->json($user);
         }
 
-        public function login(Request $request)
+    public function login(Request $request)
         {
             $userDTO = new RequestLoginUserDto(
                 $request->input('email'),
@@ -38,6 +39,28 @@
                 return response()->json(['message' => 'Invalid credentials'], 401);
             }
 
-            return response()->json($user);
-        }
+        return response()->json($user);
     }
+
+    public function index()
+    {
+        return response()->json(User::all());
+    }
+
+    public function show(User $user)
+    {
+        return response()->json($user);
+    }
+
+    public function update(Request $request, User $user)
+    {
+        $user->update($request->only(['name','email','password']));
+        return response()->json($user);
+    }
+
+    public function destroy(User $user)
+    {
+        $user->delete();
+        return response()->noContent();
+    }
+}

--- a/user-service/routes/api.php
+++ b/user-service/routes/api.php
@@ -8,4 +8,6 @@
     });
 
     Route::post('/register', [UserController::class, 'register']);
-    Route::post('/login', [UserController::class, 'login']);
+Route::post('/login', [UserController::class, 'login']);
+
+Route::apiResource('users', UserController::class)->except(['store']);


### PR DESCRIPTION
## Summary
- implement CRUD endpoints for analytics, catalog, notification, order, payment, and user microservices
- add migrations and models for events, products, notifications, orders, and payments
- expose user CRUD endpoints

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*