### PR TITLE
Add Notification API routes and controller

### DIFF
--- a/notification-service/app/Http/Controllers/NotificationController.php
+++ b/notification-service/app/Http/Controllers/NotificationController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class NotificationController extends Controller
+{
+    public function index(string $version)
+    {
+        return response()->json(['version' => $version, 'method' => 'index']);
+    }
+
+    public function store(Request $request, string $version)
+    {
+        return response()->json([
+            'version' => $version,
+            'method' => 'store',
+            'data' => $request->all(),
+        ]);
+    }
+
+    public function show(string $version, string $id)
+    {
+        return response()->json([
+            'version' => $version,
+            'method' => 'show',
+            'id' => $id,
+        ]);
+    }
+
+    public function update(Request $request, string $version, string $id)
+    {
+        return response()->json([
+            'version' => $version,
+            'method' => 'update',
+            'id' => $id,
+            'data' => $request->all(),
+        ]);
+    }
+
+    public function destroy(string $version, string $id)
+    {
+        return response()->json([
+            'version' => $version,
+            'method' => 'destroy',
+            'id' => $id,
+        ]);
+    }
+}

--- a/notification-service/bootstrap/app.php
+++ b/notification-service/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/notification-service/routes/api.php
+++ b/notification-service/routes/api.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\NotificationController;
+
+Route::get('{version}/notification', [NotificationController::class, 'index'])
+    ->where('version', 'v[0-9]+');
+
+Route::post('{version}/notification', [NotificationController::class, 'store'])
+    ->where('version', 'v[0-9]+');
+
+Route::get('{version}/notification/{id}', [NotificationController::class, 'show'])
+    ->where('version', 'v[0-9]+');
+
+Route::match(['put', 'patch'], '{version}/notification/{id}', [NotificationController::class, 'update'])
+    ->where('version', 'v[0-9]+');
+
+Route::delete('{version}/notification/{id}', [NotificationController::class, 'destroy'])
+    ->where('version', 'v[0-9]+');
+

--- a/notification-service/tests/Feature/NotificationRoutesTest.php
+++ b/notification-service/tests/Feature/NotificationRoutesTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class NotificationRoutesTest extends TestCase
+{
+    public function test_index_route_responds(): void
+    {
+        $response = $this->get('/api/v1/notification');
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'version' => 'v1',
+                     'method' => 'index',
+                 ]);
+    }
+
+    public function test_store_route_responds(): void
+    {
+        $response = $this->post('/api/v1/notification', ['foo' => 'bar']);
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'version' => 'v1',
+                     'method' => 'store',
+                     'data' => ['foo' => 'bar'],
+                 ]);
+    }
+
+    public function test_show_route_responds(): void
+    {
+        $response = $this->get('/api/v1/notification/1');
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'version' => 'v1',
+                     'method' => 'show',
+                     'id' => '1',
+                 ]);
+    }
+
+    public function test_update_route_responds(): void
+    {
+        $response = $this->put('/api/v1/notification/1', ['foo' => 'bar']);
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'version' => 'v1',
+                     'method' => 'update',
+                     'id' => '1',
+                 ]);
+    }
+
+    public function test_delete_route_responds(): void
+    {
+        $response = $this->delete('/api/v1/notification/1');
+
+        $response->assertStatus(200)
+                 ->assertJson([
+                     'version' => 'v1',
+                     'method' => 'destroy',
+                     'id' => '1',
+                 ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add NotificationController with CRUD handlers
- create `api.php` with versioned notification endpoints
- enable api routing in bootstrap
- add feature tests covering CRUD routes

## Testing
- `php artisan test` *(fails: `php: command not found`)*