### PR TITLE
Implement catalog service API routes

### DIFF
--- a/catalog-service/app/Http/Controllers/V1/CatalogController.php
+++ b/catalog-service/app/Http/Controllers/V1/CatalogController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class CatalogController extends Controller
+{
+    public function index()
+    {
+        return response()->json(['items' => []]);
+    }
+
+    public function show(string $id)
+    {
+        return response()->json(['id' => (int) $id]);
+    }
+
+    public function store(Request $request)
+    {
+        return response()->json([
+            'created' => true,
+            'data' => $request->all(),
+        ], 201);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        return response()->json([
+            'updated' => true,
+            'id' => (int) $id,
+            'data' => $request->all(),
+        ]);
+    }
+
+    public function destroy(string $id)
+    {
+        return response()->json(null, 204);
+    }
+}
+

--- a/catalog-service/routes/api.php
+++ b/catalog-service/routes/api.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\V1\CatalogController;
+
+Route::prefix('{version}')
+    ->where('version', 'v[0-9]+')
+    ->group(function () {
+        Route::get('items', [CatalogController::class, 'index']);
+        Route::get('items/{id}', [CatalogController::class, 'show']);
+        Route::post('items', [CatalogController::class, 'store']);
+        Route::match(['put', 'patch'], 'items/{id}', [CatalogController::class, 'update']);
+        Route::delete('items/{id}', [CatalogController::class, 'destroy']);
+    });
+

--- a/catalog-service/routes/web.php
+++ b/catalog-service/routes/web.php
@@ -5,3 +5,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::prefix('api')
+    ->middleware('api')
+    ->group(base_path('routes/api.php'));

--- a/catalog-service/tests/Feature/CatalogRoutesTest.php
+++ b/catalog-service/tests/Feature/CatalogRoutesTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class CatalogRoutesTest extends TestCase
+{
+    public function test_can_list_items(): void
+    {
+        $response = $this->get('/api/v1/items');
+        $response->assertStatus(200)->assertJson(['items' => []]);
+    }
+
+    public function test_can_create_item(): void
+    {
+        $response = $this->postJson('/api/v1/items', ['name' => 'Example']);
+        $response->assertStatus(201)->assertJson(['created' => true]);
+    }
+
+    public function test_can_show_item(): void
+    {
+        $response = $this->get('/api/v1/items/1');
+        $response->assertStatus(200)->assertJson(['id' => 1]);
+    }
+
+    public function test_can_update_item(): void
+    {
+        $response = $this->patchJson('/api/v1/items/1', ['name' => 'Updated']);
+        $response->assertStatus(200)->assertJson(['updated' => true, 'id' => 1]);
+    }
+
+    public function test_can_delete_item(): void
+    {
+        $response = $this->delete('/api/v1/items/1');
+        $response->assertStatus(204);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add RESTful API routes under `catalog-service`
- include `CatalogController` for basic CRUD actions
- wire up API routes via `web.php`
- test CRUD endpoints

## Testing
- `composer test` *(fails: composer not found)*
- `php artisan test` *(fails: php not found)*