### PR TITLE
Add order service API routes and tests

### DIFF
--- a/order-service/app/Http/Controllers/OrderController.php
+++ b/order-service/app/Http/Controllers/OrderController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class OrderController extends Controller
+{
+    public function index()
+    {
+        return response()->json(['message' => 'List of orders']);
+    }
+
+    public function store(Request $request)
+    {
+        return response()->json(['message' => 'Order created'], Response::HTTP_CREATED);
+    }
+
+    public function update(Request $request, $order)
+    {
+        return response()->json(['message' => "Order {$order} updated"]);
+    }
+
+    public function destroy($order)
+    {
+        return response()->json(['message' => "Order {$order} deleted"]);
+    }
+}

--- a/order-service/routes/api.php
+++ b/order-service/routes/api.php
@@ -1,0 +1,12 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\OrderController;
+
+Route::prefix('v1')->group(function () {
+    Route::get('/orders', [OrderController::class, 'index']);
+    Route::post('/orders', [OrderController::class, 'store']);
+    Route::match(['put', 'patch'], '/orders/{order}', [OrderController::class, 'update']);
+    Route::delete('/orders/{order}', [OrderController::class, 'destroy']);
+});
+

--- a/order-service/tests/Feature/OrderRoutesTest.php
+++ b/order-service/tests/Feature/OrderRoutesTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class OrderRoutesTest extends TestCase
+{
+    public function test_can_get_orders(): void
+    {
+        $response = $this->get('/api/v1/orders');
+        $response->assertStatus(200);
+    }
+
+    public function test_can_create_order(): void
+    {
+        $response = $this->postJson('/api/v1/orders', ['name' => 'Test']);
+        $response->assertStatus(201);
+    }
+
+    public function test_can_update_order(): void
+    {
+        $response = $this->putJson('/api/v1/orders/1', ['name' => 'Updated']);
+        $response->assertStatus(200);
+    }
+
+    public function test_can_delete_order(): void
+    {
+        $response = $this->delete('/api/v1/orders/1');
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- add API routes for orders with versioning
- implement `OrderController` with basic REST actions
- cover HTTP verb routes with feature tests

## Testing
- `composer test` *(fails: composer not found)*
- `php artisan test` *(fails: php not found)*