### PR TITLE
Add analytics API routes and tests

### DIFF
--- a/analytics-service/app/Http/Controllers/AnalyticsController.php
+++ b/analytics-service/app/Http/Controllers/AnalyticsController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class AnalyticsController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        return response()->json(['message' => 'index']);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        return response()->json(['message' => 'stored'], 201);
+    }
+
+    public function update(Request $request, string $id): JsonResponse
+    {
+        return response()->json(['message' => 'updated', 'id' => $id]);
+    }
+
+    public function destroy(string $id): JsonResponse
+    {
+        return response()->json(['message' => 'deleted', 'id' => $id]);
+    }
+}

--- a/analytics-service/bootstrap/app.php
+++ b/analytics-service/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/analytics-service/routes/api.php
+++ b/analytics-service/routes/api.php
@@ -1,0 +1,11 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AnalyticsController;
+
+Route::prefix('v1')->group(function () {
+    Route::get('analytics', [AnalyticsController::class, 'index']);
+    Route::post('analytics', [AnalyticsController::class, 'store']);
+    Route::match(['put', 'patch'], 'analytics/{id}', [AnalyticsController::class, 'update']);
+    Route::delete('analytics/{id}', [AnalyticsController::class, 'destroy']);
+});

--- a/analytics-service/tests/Feature/AnalyticsRoutesTest.php
+++ b/analytics-service/tests/Feature/AnalyticsRoutesTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class AnalyticsRoutesTest extends TestCase
+{
+    public function test_get_route_returns_successful_response(): void
+    {
+        $response = $this->get('/api/v1/analytics');
+        $response->assertStatus(200);
+    }
+
+    public function test_post_route_returns_successful_response(): void
+    {
+        $response = $this->post('/api/v1/analytics', ['foo' => 'bar']);
+        $response->assertStatus(201);
+    }
+
+    public function test_put_route_returns_successful_response(): void
+    {
+        $response = $this->put('/api/v1/analytics/1', ['foo' => 'bar']);
+        $response->assertStatus(200);
+    }
+
+    public function test_patch_route_returns_successful_response(): void
+    {
+        $response = $this->patch('/api/v1/analytics/1', ['foo' => 'bar']);
+        $response->assertStatus(200);
+    }
+
+    public function test_delete_route_returns_successful_response(): void
+    {
+        $response = $this->delete('/api/v1/analytics/1');
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- create `api.php` routes for analytics service
- implement `AnalyticsController` with basic CRUD responses
- register API routes in analytics service bootstrap
- add feature tests covering all CRUD routes

## Testing
- `phpunit` *(fails: command not found)*