### PR TITLE
Add CRUD endpoints to user-service

### DIFF
--- a/user-service/app/Http/Controllers/UserController.php
+++ b/user-service/app/Http/Controllers/UserController.php
@@ -1,9 +1,12 @@
 <?php
     namespace App\Http\Controllers;
 
+    use App\DTO\Requests\UserRequest\RequestDeleteUserDto;
     use App\DTO\Requests\UserRequest\RequestInsertUserDto;
     use App\DTO\Requests\UserRequest\RequestLoginUserDto;
+    use App\DTO\Requests\UserRequest\RequestUpdateUserDto;
     use App\Services\UserServices\UserService;
+    use App\Models\User;
     use Illuminate\Http\Request;
 
     class UserController extends Controller
@@ -26,18 +29,50 @@
             return response()->json($user);
         }
 
-        public function login(Request $request)
-        {
-            $userDTO = new RequestLoginUserDto(
-                $request->input('email'),
-                $request->input('password')
-            );
-            $user = $this->userService->login($userDTO);
+    public function login(Request $request)
+    {
+        $userDTO = new RequestLoginUserDto(
+            $request->input('email'),
+            $request->input('password')
+        );
+        $user = $this->userService->login($userDTO);
 
             if (! $user) {
-                return response()->json(['message' => 'Invalid credentials'], 401);
-            }
-
-            return response()->json($user);
+            return response()->json(['message' => 'Invalid credentials'], 401);
         }
+
+        return response()->json($user);
     }
+
+    public function index()
+    {
+        $users = $this->userService->getAllUsers();
+        return response()->json($users);
+    }
+
+    public function show(User $user)
+    {
+        return response()->json($user);
+    }
+
+    public function update(Request $request, User $user)
+    {
+        $userDTO = new RequestUpdateUserDto(
+            (string) $user->id,
+            $request->input('name', $user->name),
+            $request->input('email', $user->email),
+            $request->input('password', $user->password)
+        );
+
+        $updated = $this->userService->updateUser($userDTO);
+
+        return response()->json($updated);
+    }
+
+    public function destroy(User $user)
+    {
+        $userDTO = new RequestDeleteUserDto((string) $user->id);
+        $this->userService->deleteUser($userDTO);
+        return response()->json(null, 204);
+    }
+}

--- a/user-service/app/Services/UserServices/UserService.php
+++ b/user-service/app/Services/UserServices/UserService.php
@@ -1,10 +1,13 @@
 <?php
     namespace App\Services\UserServices;
 
+    use App\DTO\Requests\UserRequest\RequestDeleteUserDto;
     use App\DTO\Requests\UserRequest\RequestInsertUserDto;
     use App\DTO\Requests\UserRequest\RequestLoginUserDto;
+    use App\DTO\Requests\UserRequest\RequestUpdateUserDto;
     use App\Models\User;
     use Illuminate\Support\Facades\Hash;
+    use Illuminate\Support\Collection;
 
 class UserService
 {
@@ -30,5 +33,39 @@ class UserService
         }
 
         return $user;
+    }
+
+    public function getAllUsers(): Collection
+    {
+        return User::all();
+    }
+
+    public function updateUser(RequestUpdateUserDto $userDTO): ?User
+    {
+        $user = User::find($userDTO->idUser);
+        if (! $user) {
+            return null;
+        }
+
+        $user->name = $userDTO->name;
+        $user->email = $userDTO->email;
+
+        if ($userDTO->password !== '') {
+            $user->password = $userDTO->password;
+        }
+
+        $user->save();
+
+        return $user;
+    }
+
+    public function deleteUser(RequestDeleteUserDto $userDTO): bool
+    {
+        $user = User::find($userDTO->idUser);
+        if (! $user) {
+            return false;
+        }
+
+        return (bool) $user->delete();
     }
 }

--- a/user-service/routes/api.php
+++ b/user-service/routes/api.php
@@ -7,5 +7,12 @@
         return response()->json(['message' => 'Hello world!']);
     });
 
-    Route::post('/register', [UserController::class, 'register']);
-    Route::post('/login', [UserController::class, 'login']);
+    Route::prefix('v1')->group(function () {
+        Route::post('/register', [UserController::class, 'register']);
+        Route::post('/login', [UserController::class, 'login']);
+
+        Route::get('/users', [UserController::class, 'index']);
+        Route::get('/users/{user}', [UserController::class, 'show']);
+        Route::match(['put', 'patch'], '/users/{user}', [UserController::class, 'update']);
+        Route::delete('/users/{user}', [UserController::class, 'destroy']);
+    });

--- a/user-service/tests/Feature/UserCrudTest.php
+++ b/user-service/tests/Feature/UserCrudTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_crud_v1(): void
+    {
+        // Create
+        $response = $this->postJson('/api/v1/register', [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'password' => 'secret',
+        ]);
+        $response->assertStatus(200);
+        $userId = $response->json('id');
+
+        // Index
+        $this->getJson('/api/v1/users')->assertStatus(200);
+
+        // Show
+        $this->getJson("/api/v1/users/{$userId}")->assertStatus(200);
+
+        // Update
+        $this->putJson("/api/v1/users/{$userId}", [
+            'name' => 'Updated',
+            'email' => 'updated@example.com',
+            'password' => 'newsecret',
+        ])->assertStatus(200)->assertJson(['name' => 'Updated']);
+
+        // Delete
+        $this->deleteJson("/api/v1/users/{$userId}")->assertStatus(204);
+    }
+}


### PR DESCRIPTION
## Summary
- add user API prefix with CRUD endpoints
- implement controller actions for listing, showing, updating and deleting users
- add service methods for retrieving, updating and deleting users
- add feature test covering CRUD operations via v1 routes

## Testing
- `php artisan test` *(fails: `php: command not found`)*