### PR TITLE
Add payment controller with API routes

### DIFF
--- a/payment-service/app/Http/Controllers/PaymentController.php
+++ b/payment-service/app/Http/Controllers/PaymentController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class PaymentController extends Controller
+{
+    public function index()
+    {
+        return response()->json(['message' => 'list payments']);
+    }
+
+    public function store(Request $request)
+    {
+        return response()->json(['message' => 'create payment'], 201);
+    }
+
+    public function show(string $id)
+    {
+        return response()->json(['message' => 'show payment', 'id' => $id]);
+    }
+
+    public function update(Request $request, string $id)
+    {
+        return response()->json(['message' => 'update payment', 'id' => $id]);
+    }
+
+    public function destroy(string $id)
+    {
+        return response()->json(['message' => 'delete payment', 'id' => $id]);
+    }
+}

--- a/payment-service/routes/api.php
+++ b/payment-service/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\PaymentController;
+
+Route::prefix('v1')->group(function () {
+    Route::apiResource('payment', PaymentController::class);
+});

--- a/payment-service/routes/web.php
+++ b/payment-service/routes/web.php
@@ -5,3 +5,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::prefix('api')
+    ->middleware('api')
+    ->group(base_path('routes/api.php'));

--- a/payment-service/tests/Feature/PaymentRoutesTest.php
+++ b/payment-service/tests/Feature/PaymentRoutesTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class PaymentRoutesTest extends TestCase
+{
+    public function test_index_returns_successful_response(): void
+    {
+        $this->get('/api/v1/payment')->assertStatus(200);
+    }
+
+    public function test_store_returns_created_response(): void
+    {
+        $payload = ['order_id' => '1', 'amount' => 10.0, 'method' => 'card'];
+        $this->postJson('/api/v1/payment', $payload)->assertStatus(201);
+    }
+
+    public function test_show_returns_successful_response(): void
+    {
+        $this->get('/api/v1/payment/1')->assertStatus(200);
+    }
+
+    public function test_update_returns_successful_response(): void
+    {
+        $payload = ['amount' => 20.0, 'method' => 'cash'];
+        $this->putJson('/api/v1/payment/1', $payload)->assertStatus(200);
+    }
+
+    public function test_delete_returns_successful_response(): void
+    {
+        $this->delete('/api/v1/payment/1')->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- implement versioned payment routes
- add `PaymentController` with CRUD stubs
- hook API routes via web.php prefix
- create feature tests for payment endpoints

## Testing
- `php artisan test` *(fails: `bash: php: command not found`)*