### PR TITLE
Add allowed method checks to gateway

### DIFF
--- a/laravel-gateway/app/Http/Controllers/GatewayController.php
+++ b/laravel-gateway/app/Http/Controllers/GatewayController.php
@@ -28,6 +28,12 @@
                 return response()->json(['error' => 'Service not found'], Response::HTTP_NOT_FOUND);
             }
 
+            // 4.1) Method allowed check
+            $allowed = $route['allowed_methods'] ?? [];
+            if ($allowed && !in_array($request->method(), $allowed)) {
+                return response()->json(['error' => 'Method Not Allowed'], Response::HTTP_METHOD_NOT_ALLOWED);
+            }
+
             // 5) Build target URL
             $url  = $route['url']."/{$service}/{$version}";
             if ($parameters) {

--- a/laravel-gateway/config/gateway_routes.php
+++ b/laravel-gateway/config/gateway_routes.php
@@ -13,6 +13,7 @@
             'cache_ttl'    => 3600,
             'auth'         => false,
             'rate_limit'   => 60,
+            'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
         ],
 
         // Auth
@@ -21,6 +22,7 @@
             'cache_ttl'    => 0,
             'auth'         => false,
             'rate_limit'   => 60,
+            'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
         ],
 
         // Catalog
@@ -29,6 +31,7 @@
             'cache_ttl'    => 3600,
             'auth'         => false,
             'rate_limit'   => 60,
+            'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
         ],
 
         // JWT
@@ -37,6 +40,7 @@
             'cache_ttl'    => 3600,
             'auth'         => false,
             'rate_limit'   => 60,
+            'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
         ],
 
         // Notification
@@ -45,6 +49,7 @@
             'cache_ttl'    => 3600,
             'auth'         => false,
             'rate_limit'   => 60,
+            'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
         ],
 
         // Order (requires auth)
@@ -53,9 +58,10 @@
             'cache_ttl'    => 0,
             'auth'         => true,
             'rate_limit'   => 60,
+            'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+        ],
 
-
-            /*
+        /*
         'order' => [
             'url'       => 'http://order-service:80/api',
     cache:
@@ -79,6 +85,7 @@
             'cache_ttl'    => 0,
             'auth'         => true,
             'rate_limit'   => 60,
+            'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
         ],
 
         // Users (caching reads, requires auth)
@@ -87,6 +94,7 @@
             'cache_ttl'    => 300,
             'auth'         => false,
             'rate_limit'   => 100,
+            'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
         ],
 
     ];

--- a/laravel-gateway/routes/api.php
+++ b/laravel-gateway/routes/api.php
@@ -17,14 +17,21 @@
     */
 
     // Catch all under /api/v1/{service}/{path?}
-    Route::any('v1/', [GatewayController::class,'proxy']);
+    $routesConfig = require config_path('gateway_routes.php');
+    $gatewayMethods = [];
+    foreach ($routesConfig as $config) {
+        $gatewayMethods = array_merge($gatewayMethods, $config['allowed_methods'] ?? []);
+    }
+    $gatewayMethods = array_values(array_unique($gatewayMethods));
+
+    Route::match($gatewayMethods, 'v1/', [GatewayController::class,'proxy']);
         //->where('version','v[0-9]+')
         //->where('path', '.*');
 
     //Route::any('v1/{service}', [GatewayController::class,'proxy']);
 
     //Route::any('v1/{service}/{path}', [GatewayController::class,'proxy']);
-    Route::any('{version}/{service}/{parameters?}', [GatewayController::class,'proxy'])
+    Route::match($gatewayMethods, '{version}/{service}/{parameters?}', [GatewayController::class,'proxy'])
         ->where('version', 'v[0-9]+')          // v1, v2, v12…
         ->where('service', '[A-Za-z0-9\\-]+')  // utenti, order-service…
         ->where('parameters', '.*');           // zero o più segmenti

--- a/laravel-gateway/tests/Feature/MethodNotAllowedTest.php
+++ b/laravel-gateway/tests/Feature/MethodNotAllowedTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class MethodNotAllowedTest extends TestCase
+{
+    public function test_options_method_is_rejected()
+    {
+        $response = $this->call('OPTIONS', '/api/v1/analytics');
+        $response->assertStatus(405);
+    }
+
+    public function test_config_disallows_method()
+    {
+        config(['gateway_routes.analytics.allowed_methods' => ['GET']]);
+        $response = $this->post('/api/v1/analytics');
+        $response->assertStatus(405);
+    }
+}


### PR DESCRIPTION
## Summary
- define `allowed_methods` for each gateway service
- build method list dynamically and delegate only those methods
- reject requests with unconfigured HTTP methods in GatewayController
- test that disallowed methods yield HTTP 405

## Testing
- `vendor/bin/phpunit --filter MethodNotAllowedTest` *(fails: `bash: vendor/bin/phpunit: No such file or directory`)*