### PR TITLE
Reconfigure Kong gateway

### DIFF
--- a/kong-gateway/kong.yml
+++ b/kong-gateway/kong.yml
@@ -1,2 +1,74 @@
 _format_version: "3.0"
-services: []
+
+services:
+  - name: analytics
+    url: http://analytics-service:80
+    routes:
+      - name: analytics
+        paths:
+          - /api/v1/analytics
+        strip_path: false
+        methods: [GET, POST, PUT, PATCH, DELETE]
+
+  - name: auth
+    url: http://auth-service:80
+    routes:
+      - name: auth
+        paths:
+          - /api/v1/auth
+        strip_path: false
+        methods: [GET, POST, PUT, PATCH, DELETE]
+
+  - name: catalog
+    url: http://catalog-service:80
+    routes:
+      - name: catalog
+        paths:
+          - /api/v1/catalog
+        strip_path: false
+        methods: [GET, POST, PUT, PATCH, DELETE]
+
+  - name: jwt
+    url: http://jwt-service:80
+    routes:
+      - name: jwt
+        paths:
+          - /api/v1/jwt
+        strip_path: false
+        methods: [GET, POST, PUT, PATCH, DELETE]
+
+  - name: notification
+    url: http://notification-service:80
+    routes:
+      - name: notification
+        paths:
+          - /api/v1/notification
+        strip_path: false
+        methods: [GET, POST, PUT, PATCH, DELETE]
+
+  - name: order
+    url: http://order-service:80
+    routes:
+      - name: order
+        paths:
+          - /api/v1/order
+        strip_path: false
+        methods: [GET, POST, PUT, PATCH, DELETE]
+
+  - name: payment
+    url: http://payment-service:80
+    routes:
+      - name: payment
+        paths:
+          - /api/v1/payment
+        strip_path: false
+        methods: [GET, POST, PUT, PATCH, DELETE]
+
+  - name: users
+    url: http://user-service:80
+    routes:
+      - name: users
+        paths:
+          - /api/v1/users
+        strip_path: false
+        methods: [GET, POST, PUT, PATCH, DELETE]


### PR DESCRIPTION
## Summary
- revert previous Laravel Gateway method restrictions
- configure Kong gateway routes with allowed HTTP methods

## Testing
- `vendor/bin/phpunit --filter ExampleTest` *(fails: `bash: vendor/bin/phpunit: No such file or directory`)*